### PR TITLE
fix: 一時ファイルをタイムスタンプ付きファイル名に変更

### DIFF
--- a/.claude/skills/prompt-review/SKILL.md
+++ b/.claude/skills/prompt-review/SKILL.md
@@ -31,10 +31,12 @@ context: fork
 
 ### 引数からスクリプトオプションを組み立てる
 
-`$ARGUMENTS` を解析し、Bash で以下のように実行する:
+`$ARGUMENTS` を解析し、Bash で以下のように実行する。
+**実行前にタイムスタンプ付きのファイル名を生成し、スクリプト出力の保存先と Read の参照先で同じパスを使うこと。**
 
 ```bash
-python ~/.claude/skills/prompt-review/scripts/collect.py [OPTIONS] > /tmp/prompt-review-data.json
+OUTFILE="/tmp/prompt-review-data_$(date +%Y%m%d%H%M%S).json"
+python ~/.claude/skills/prompt-review/scripts/collect.py [OPTIONS] > "$OUTFILE"
 ```
 
 - 引数なし → オプションなし（デフォルト: 過去7日分）
@@ -47,7 +49,7 @@ python ~/.claude/skills/prompt-review/scripts/collect.py [OPTIONS] > /tmp/prompt
 
 ### 出力の読み取り
 
-スクリプト実行後、`/tmp/prompt-review-data.json` を Read で読み込む。
+スクリプト実行後、上記で生成した `$OUTFILE` のパスを Read で読み込む。
 
 出力JSON構造:
 ```json
@@ -87,7 +89,7 @@ python ~/.claude/skills/prompt-review/scripts/collect.py [OPTIONS] > /tmp/prompt
 
 ## ステップ2: 分析
 
-Read で `/tmp/prompt-review-data.json` を読み込んだら、以下の観点で `messages` 配列内のユーザープロンプトを分析する。各観点について**具体的なエビデンス**（実際のプロンプト断片の引用）を必ず含めること。
+Read で `$OUTFILE`（ステップ1で生成したタイムスタンプ付きファイル）を読み込んだら、以下の観点で `messages` 配列内のユーザープロンプトを分析する。各観点について**具体的なエビデンス**（実際のプロンプト断片の引用）を必ず含めること。
 
 ### 前処理: プロジェクト別サマリーの作成と短文応答の除外
 


### PR DESCRIPTION
## 問題
`/tmp/prompt-review-data.json` という固定ファイル名を使用していたため、 別セッションで生成されたキャッシュが残っていた場合にそれを読み込んでしまう
不具合があった。

## 修正内容
- 一時ファイル名を `/tmp/prompt-review-data_YYYYMMDDHHMMSS.json` 形式に変更
- Bash コマンド例に `OUTFILE` 変数でファイル名を先に生成するステップを追加
- 出力の読み取り・ステップ2の説明を `$OUTFILE` 参照に統一

## 副次効果
- 実行ごとにファイルが別名で保存されるため、過去の収集結果と比較できる
- 古いファイルの削除が不要になる