### PR TITLE
feat: Codex App の archived_sessions を収集対象に追加

### DIFF
--- a/.claude/skills/prompt-review/references/data-sources.md
+++ b/.claude/skills/prompt-review/references/data-sources.md
@@ -344,7 +344,7 @@ Cline と同じ手順。
 | macOS | `~/.codex/sessions/` |
 | Linux | `~/.codex/sessions/` |
 
-環境変数 `CODEX_HOME` が設定されている場合は、`$CODEX_HOME/sessions/` を使用する。
+環境変数 `CODEX_HOME` が設定されている場合は、`$CODEX_HOME/sessions/` および `$CODEX_HOME/archived_sessions/` を使用する。
 
 ### ファイル構造
 ```
@@ -355,6 +355,8 @@ Cline と同じ手順。
 └── sessions/
     └── YYYY/MM/DD/
         └── rollout-YYYY-MM-DDThh-mm-ss-<id>.jsonl # セッション別会話ログ
+└── archived_sessions/
+    └── rollout-YYYY-MM-DDThh-mm-ss-<id>.jsonl     # アーカイブ済み会話ログ
 ```
 
 ### rollout JSONL の形式
@@ -371,7 +373,7 @@ Cline と同じ手順。
 ```
 
 ### 抽出方法
-1. `~/.codex/sessions/` 配下の `rollout-*.jsonl` を再帰的に走査（最新50件）
+1. `~/.codex/sessions/` と `~/.codex/archived_sessions/` 配下の `rollout-*.jsonl` を再帰的に走査（最新50件）
 2. 各行の `type` と `payload` を読み取り、`type` が存在しない行はスキップ
 3. `session_meta` の `payload.cwd` でプロジェクト情報を取得
 4. `response_item` で `payload.type: "message"`, `payload.role: "user"` のメッセージを抽出
@@ -380,6 +382,7 @@ Cline と同じ手順。
 
 ### 注意事項
 - セッションはグローバル保存（プロジェクト別ディレクトリではない）
+- `archived_sessions` は Codex アプリでアーカイブしたスレッドの保存先
 - プロジェクト情報は `session_meta` の `payload.cwd` フィールドから取得
 - `state-v5.db` にもスレッドメタデータがあるが、会話内容は rollout JSONL に保存される
 

--- a/.claude/skills/prompt-review/scripts/collect.py
+++ b/.claude/skills/prompt-review/scripts/collect.py
@@ -808,19 +808,20 @@ def collect_gemini_cli(cutoff_ms: int | None, project_filter: str | None) -> dic
 
 
 def collect_codex(cutoff_ms: int | None, project_filter: str | None) -> dict:
-    """OpenAI Codex CLI の rollout JSONL からユーザープロンプトを収集"""
+    """OpenAI Codex の rollout JSONL からユーザープロンプトを収集"""
     result = {"tool": "OpenAI Codex", "status": "未検出", "messages": [], "period": ""}
 
     codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
     sessions_dir = codex_home / "sessions"
-    if not sessions_dir.exists():
+    archived_dir = codex_home / "archived_sessions"
+    if not sessions_dir.exists() and not archived_dir.exists():
         return result
 
     messages = []
 
-    # sessions/YYYY/MM/DD/rollout-*.jsonl を走査
+    # sessions/YYYY/MM/DD/rollout-*.jsonl と archived_sessions/rollout-*.jsonl を走査
     rollout_files = sorted(
-        sessions_dir.rglob("rollout-*.jsonl"),
+        [*sessions_dir.rglob("rollout-*.jsonl"), *archived_dir.rglob("rollout-*.jsonl")],
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )[:50]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Claude Code のスキルとして動作する、AIエージェント対話履歴
 | Windsurf (Cascade) | テキスト（自動要約メモリ） |
 | Google Antigravity | テキスト（ログファイル） |
 | Gemini CLI | JSON / JSONL（セッションファイル） |
-| OpenAI Codex（CLI） | JSONL（rollout セッションファイル） |
+| OpenAI Codex（CLI / App） | JSONL（rollout セッションファイル） |
 | OpenCode | SQLite（`opencode.db` / `opencode-<channel>.db`） |
 
 ## 使い方


### PR DESCRIPTION
## 背景
Codex CLI は `~/.codex/sessions/` または `$CODEX_HOME/sessions/` に会話履歴を保存します。

Codex App も同じ場所に会話履歴を保存しますが、Codex App にはアーカイブ機能があり、アーカイブされた会話履歴は `~/.codex/archived_sessions/` または `$CODEX_HOME/archived_sessions/` に保存されます。

現在の実装では `sessions/` だけが収集対象になっていたため、Codex App でアーカイブ済みの会話履歴はプロンプトレビューの分析対象になっていませんでした。

## 概要
- Codex のプロンプト収集対象に `archived_sessions` を追加
- データソース説明に `archived_sessions` の保存場所を追記
- README の対応表記を Codex CLI / App に更新

## 確認
- `python3 -m py_compile .claude/skills/prompt-review/scripts/collect.py`
- 存在する `sessions` ディレクトリと、存在しないディレクトリを指定してもエラーにならないことを確認